### PR TITLE
fix rate limiting bug with github access checking

### DIFF
--- a/statstool
+++ b/statstool
@@ -162,7 +162,7 @@ if [ -z "${DATADIR}" ] || [ ! -e "${DATADIR}" ] ; then
 
     echo "checking access to github for ${REPO}..."
     REPO_URL="https://api.github.com/repos/${REPO}"
-    curl -L --compressed -s -H "Authorization: token ${GITHUB_TOKEN}" "${REPO_URL}" > ${DATADIR}/repo
+    echo ${REPO_URL} | GITHUB_TOKEN=$GITHUB_TOKEN ${DIR}/fetch-comments.sh > ${DATADIR}/repo
     if ! cat ${DATADIR}/repo | jq '.full_name' | ag -v '^null$' > /dev/null; then
         echo "no access to ${REPO_URL}"
         echo "check that your access token has access to the repos scope"


### PR DESCRIPTION
Verified by:
1. running statstool pre-fix
2. running statstool post-fix without hitting rate limit
3. running statstool post-fix while hitting rate limit
4. verified in all 3 cases files generated are exactly the same (by comparing file sizes)
    * except repo, which in pre-fix was a pretty printed json, but post-fix, is just a giant single line json blob
    * verified that after adjusting whitespace, the generated jsons were exactly the same